### PR TITLE
AoC22 more checks due to the fix in benchmark code

### DIFF
--- a/AoC22/cpp/CMakeLists.txt
+++ b/AoC22/cpp/CMakeLists.txt
@@ -11,8 +11,7 @@ else()
     # TODO - lots of warnings and all warnings as errors
     # removed to make almost clean Abseil: -Wall -Wextra -Werror -pedantic
     # -fexperimental-library - to be able to use experimental features like ranges/views
-    # -Wno-unused-but-set-variable - to be able to compile benchmark
-    add_compile_options(-Wno-deprecated -fno-exceptions -Wno-unused-but-set-variable -fno-rtti)
+    add_compile_options(-Wno-deprecated -fno-exceptions -fno-rtti)
 endif()
 
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address") #memory - cannot together with address #undefined,dataflow


### PR DESCRIPTION
https://github.com/google/benchmark/pull/1517 is merged, so we should be able to compile now also witho `-Wno-unused-but-set-variable`