### PR TITLE
Remove dependency from rangev3

### DIFF
--- a/AoC22/README.md
+++ b/AoC22/README.md
@@ -1,11 +1,10 @@
 # Technological Stack & Conventions
 * C++ 20
 * Clang 15
-* no exceptions (but with flags exceptions and RTTI due to range-v3)
+* no exceptions
 * Google Test
 * Abseil
 * clang-format
 * re2
 * benchmark
-* range-v3 0.12.0 (Clang and even GCC still have issues with C++20 ranges)
 * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)

--- a/AoC22/cpp/CMakeLists.txt
+++ b/AoC22/cpp/CMakeLists.txt
@@ -11,8 +11,7 @@ else()
     # TODO - lots of warnings and all warnings as errors
     # removed to make almost clean Abseil: -Wall -Wextra -Werror -pedantic
     # -fexperimental-library - to be able to use experimental features like ranges/views    
-    # -fno-exceptions -fno-rtti - exceptions and RTTI are required for range-v3 implementation
-    add_compile_options(-Wno-deprecated)    
+    add_compile_options(-Wno-deprecated -fno-exceptions -fno-rtti)    
 endif()
 
 # if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
@@ -41,20 +40,14 @@ FetchContent_Declare(re2
     GIT_REPOSITORY "https://github.com/google/re2"
     GIT_TAG 2023-03-01 ) # working 2022-12-01, 2023-03-01 broken on 2023-06-01
 
-# requires exceptions
-FetchContent_Declare(range-v3
-    GIT_REPOSITORY "https://github.com/ericniebler/range-v3"
-    GIT_TAG "0.12.0" )
-
 FetchContent_MakeAvailable(absl)
 FetchContent_MakeAvailable(gtest)
 FetchContent_MakeAvailable(benchmark)
 FetchContent_MakeAvailable(re2)
-FetchContent_MakeAvailable(range-v3)
 
 file( GLOB SOURCES day*.cpp common.cpp)
 # set(CMAKE_CXX_CPPCHECK "cppcheck")
 # set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*")
 add_executable(aoc22 test.cpp ${SOURCES}  )
 
-target_link_libraries(aoc22 PRIVATE absl::flat_hash_set absl::strings gtest re2 absl::statusor benchmark range-v3)
+target_link_libraries(aoc22 PRIVATE absl::flat_hash_set absl::strings gtest re2 absl::statusor benchmark)

--- a/AoC22/cpp/common.h
+++ b/AoC22/cpp/common.h
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <fstream>
 #include <numeric>
-// #include <ranges>
-#include <range/v3/all.hpp> // get everything for external implementation
 #include <string>
 #include <string_view>
 #include <vector>
@@ -12,10 +10,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "gtest/gtest.h"
-
-// mapping to hide external dependency on ranges
-namespace r = ranges;
-namespace rv = ranges::views;
 
 // to filter out slow tests
 [[nodiscard]] inline bool IsFastOnly() noexcept { return true; }

--- a/AoC22/cpp/day22.cpp
+++ b/AoC22/cpp/day22.cpp
@@ -1,6 +1,6 @@
 #include "common.h"
-#include "re2/re2.h
 #include "absl/algorithm/container.h"
+#include "re2/re2.h"
 
 namespace day22 {
 

--- a/AoC22/cpp/day22.cpp
+++ b/AoC22/cpp/day22.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
-#include "re2/re2.h"
+#include "re2/re2.h
+#include "absl/algorithm/container.h"
 
 namespace day22 {
 
@@ -23,10 +24,10 @@ constexpr char TILE = '.';
 
 [[nodiscard]] std::pair<Map, std::string> Load(std::string_view file) noexcept {
   const auto data = ReadData(file);
-  const auto map = data | rv::filter([](const std::string &s) {
-                     return s.find(TILE) != std::string::npos;
-                   }) |
-                   r::to<std::vector>();
+  Map map;
+  absl::c_copy_if(data, std::back_inserter(map), [](const std::string &s) {
+    return s.find(TILE) != std::string::npos;
+  });
   const std::string path = *(data.rbegin());
   return {map, path};
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Advent of Code
 
-## 2022 - C++ 23 
+## 2022 - C++ 20 
 https://adventofcode.com/2021
 
 ## 2021 - C# 10, .NET 6 (rank 7127)
@@ -9,14 +9,14 @@ https://adventofcode.com/2021
 ## 2020 - C++ 17 (rank 3550)
 https://adventofcode.com/2020
 
-## 2019 - Java, F#, C++ 20 (rank 3688)
+## 2019 - Java 17, F#, C++ 20 (rank 3688)
 https://adventofcode.com/2019
 
 ## 2018 - C# 9, .NET 5 (rank 3009)
 Originally written in .NET Core 2.1 (C# 7.3)
 https://adventofcode.com/2018
 
-## 2017 - Rust, Scala, C# (rank 5483)
+## 2017 - Rust 2021, Scala, C# (rank 5483)
 https://adventofcode.com/2017
 
 ## 2016 - Java 17 (rank 2403)


### PR DESCRIPTION
This forces to support exceptions and RTTI, moreover does not provide significant advantages (max few lines shorter).