### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,20 @@
 # Advent of Code
 
-## 2022 - C++ 20 
-https://adventofcode.com/2021
+## [2022 - C++ 20](https://adventofcode.com/2022)
 
-## 2021 - C# 10, .NET 6 (rank 7127)
-https://adventofcode.com/2021
+## [2021 - C# 10, .NET 6 (rank 7127)](https://adventofcode.com/2021)
 
-## 2020 - C++ 17 (rank 3550)
-https://adventofcode.com/2020
+## [2020 - C++ 17 (rank 3550)](https://adventofcode.com/2020)
 
-## 2019 - Java 17, F#, C++ 20 (rank 3688)
-https://adventofcode.com/2019
+## [2019 - Java 17, F#, C++ 20 (rank 3688)](https://adventofcode.com/2019)
 
-## 2018 - C# 9, .NET 5 (rank 3009)
-Originally written in .NET Core 2.1 (C# 7.3)
-https://adventofcode.com/2018
+## [2018 - C# 9, .NET 5 (rank 3009)](https://adventofcode.com/2018)
+Originally solved in .NET Core 2.1 (C# 7.3)
 
-## 2017 - Rust 2021, Scala, C# (rank 5483)
-https://adventofcode.com/2017
+## [2017 - Rust 2021, Scala, C# (rank 5483)](https://adventofcode.com/2017)
+Originally solved in Rust 2018
 
-## 2016 - Java 17 (rank 2403)
+## [2016 - Java 17 (rank 2403)](https://adventofcode.com/2016)
 Originally solved in Java 11
-https://adventofcode.com/2016
 
-## 2015 - C++ 17 (rank 3532)
-https://adventofcode.com/2015
+## [2015 - C++ 17 (rank 3532)](https://adventofcode.com/2015)


### PR DESCRIPTION
Fixed typo to 2022 was pointing to 2021.
Moved all links behind the headers.
Added note about initial version of Rust.